### PR TITLE
Feat: add logic for book rating

### DIFF
--- a/Backend/SPC.API/Controllers/BookLogController.cs
+++ b/Backend/SPC.API/Controllers/BookLogController.cs
@@ -62,5 +62,12 @@ namespace SPC.API.Controllers
       var result = await _bookLogService.DeleteBookLogId(id);
       return Ok(result);
     }
+
+    [HttpGet("ratings/{bookId}")]
+    public async Task<IActionResult> GetRatings(int bookId)
+    {
+        var ratings = await _bookLogService.GetRatingsForBook(bookId);
+        return Ok(ratings);
+    }
   }
 }

--- a/Backend/SPC.Business/Interfaces/IBookLogService.cs
+++ b/Backend/SPC.Business/Interfaces/IBookLogService.cs
@@ -9,4 +9,6 @@ public interface IBookLogService
   Task<BaseMessage<BookLog>> UpdateBookLog(BookLog bookLog);
   Task<BaseMessage<BookLog>> DeleteBookLog(BookLog bookLog);
   Task<BaseMessage<BookLog>> DeleteBookLogId(int id);
+  Task<BaseMessage<BookLog>> GetRatingsForBook(int bookId);
+  Task UpdateBookRating(int bookId);
 }

--- a/Backend/SPC.Data/Models/ApplicationUser.cs
+++ b/Backend/SPC.Data/Models/ApplicationUser.cs
@@ -4,8 +4,8 @@ namespace SPC.Data.Models;
 
 public class ApplicationUser: IdentityUser
 {
-    public string DocumentType { get; set; }
-    public string DocumentNumber { get; set; }
-    public bool TermsAceptance { get; set; }
-    public string UserType { get; set; }
+    public string DocumentType { get; set; } = String.Empty;
+    public string DocumentNumber { get; set; } = String.Empty;
+    public bool TermsAceptance { get; set; } = false;
+    public string UserType { get; set; } = String.Empty;
 }

--- a/Backend/SPC.Data/Models/Book.cs
+++ b/Backend/SPC.Data/Models/Book.cs
@@ -18,8 +18,8 @@ public class Book : BaseEntity<int>
   public string Summary{get; set;}
   public bool Deleted{get; set;}
   public int Long{get; set;}
-
   public virtual Author? Author { get; set; }
+  public double AverageRating { get; set; } = 0;
 }
 
 public enum Format

--- a/Backend/SPC.Data/Models/BookLog.cs
+++ b/Backend/SPC.Data/Models/BookLog.cs
@@ -10,9 +10,11 @@ public class BookLog : BaseEntity<int>
   [ForeignKey("BookId")]
   public int BookId{get; set;}
   public DateTime Timestamp{get; set;}
+  public int? Rating{get; set;}
+  public string? Comment{get; set;}
 
-    public virtual ApplicationUser? User { get; set; }
-    public virtual Book? Book { get; set; }
+  public virtual ApplicationUser? User { get; set; }
+  public virtual Book? Book { get; set; }
 
 }
 
@@ -24,5 +26,6 @@ public enum Action
   View,
   Delete,
   Update,
-  Create
+  Create,
+  Rate
 }

--- a/Backend/SPC.Testing/SPC/BookLogs/Get Book Rating.bru
+++ b/Backend/SPC.Testing/SPC/BookLogs/Get Book Rating.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get Book Rating
+  type: http
+  seq: 7
+}
+
+get {
+  url: http://localhost:5197/api/booklog/ratings/1
+  body: none
+  auth: inherit
+}


### PR DESCRIPTION
# Implementar servicio para la calificación de un libro

## Descripción  
Este PR agrega la implementación de dos métodos en el servicio `BookLog` para gestionar la calificación de libros y la actualización del promedio de calificación.  

## Cambios principales  
- Validación en el servicio `BookLog` para asegurar que cuando la acción sea `"rate"`, el campo `rating` no esté vacío y su valor sea entre 1 y 5.  
- Implementación de la lógica para guardar la calificación y, si la acción es `"rate"`, calcular el nuevo promedio de calificación del libro y actualizar el campo `AverageRating` en el modelo `Book`.  
- Creación del método para listar todas las calificaciones de un libro.  
- Agregadas las interfaces necesarias para los nuevos métodos del servicio.  
- Implementación del controlador con un endpoint `GET` para obtener las calificaciones de un libro. 