### PR TITLE
feature: uploadImage endpoint to upload cover for books 

### DIFF
--- a/Backend/SPC.API/Controllers/BookController.cs
+++ b/Backend/SPC.API/Controllers/BookController.cs
@@ -77,5 +77,27 @@ namespace SPC.API.Controllers
                 return StatusCode(500, $"Internal server error: {exception.Message}");
             }
         }
+
+        [HttpPost]
+        [Route("uploadImage/{id}")]
+        public async Task<IActionResult> UploadImage(int id, IFormFile file)
+        {
+            try
+            {
+                var result = await _bookService.UploadBookImage(id, file);
+                
+                return result.StatusCode switch
+                {
+                    System.Net.HttpStatusCode.OK => Ok(result),
+                    System.Net.HttpStatusCode.NotFound => NotFound(result),
+                    System.Net.HttpStatusCode.BadRequest => BadRequest(result),
+                    _ => StatusCode((int)System.Net.HttpStatusCode.InternalServerError, result)
+                };
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Internal server error: {ex.Message}");
+            }
+        }
     }
 }

--- a/Backend/SPC.Business/Interfaces/IBookService.cs
+++ b/Backend/SPC.Business/Interfaces/IBookService.cs
@@ -1,5 +1,6 @@
 using SPC.Business.Dtos;
 using SPC.Data.Models;
+using Microsoft.AspNetCore.Http;
 namespace SPC.Business.Interfaces;
 
 public interface IBookService
@@ -11,6 +12,7 @@ public interface IBookService
     Task<BaseMessage<Book>> DeleteBook(Book book);
     Task<BaseMessage<Book>> DeleteBookId(int id);
     Task<IEnumerable<Book>> SearchBooksAsync(BookSearchDto searchDto);
+    Task<BaseMessage<Book>> UploadBookImage(int bookId, IFormFile file);
 
     #region Learning to Test
     Task<string> TestBookCreation(Book book);


### PR DESCRIPTION
Upload an image of a book that exists in the database

other validations: 

- the file size must be less than 5MB
- only JPEG, JPG an PNG files


Files modified:
SPC.API/Controllers/BookController.cs
SPC.Business/Interfaces/IBookService.cs
SPC.Business/Services/BookService.cs